### PR TITLE
fix linux deadzone judgement

### DIFF
--- a/src/linux/device-linux.cpp
+++ b/src/linux/device-linux.cpp
@@ -100,9 +100,10 @@ int device_linux::update()
     if (m_event.type == JS_EVENT_AXIS) {
         if (m_native_binding) {
             vc = m_native_binding->m_axis_mappings[m_event.number];
-            auto val = float(m_event.value);
+            auto val = float(m_event.value), last_val = m_axis[vc];
+            float deadzone = m_axis_deadzones[vc] / float(0xffff);
 
-            if (fabs(val - m_last_axis_event.value) > m_axis_deadzones[vc]) {
+            if (fabs(val - last_val) > deadzone) {
                 vv = clamp(val / 0xffff + 0.5f, -1.f, 1.f);
                 m_axis[vc] = vv;
                 result = update_result::AXIS;


### PR DESCRIPTION
Hi univrsal!  Thanks for open-sourcing a brilliant gamepad library! I found a small bug when I used a gamepad in Linux. The difference in axis values is judged by `m_last_axis_event.value` and `val` instead of the old value. However, the IDs of `m_last_axis_event` and the current value do not have to be the same, especially when using analog sticks. Just as the buttons, `m_axis[vc]` is the correct value to calculate the difference.