### PR TITLE
fix(device-linux): only act on js_event when read is successful

### DIFF
--- a/src/linux/device-linux.cpp
+++ b/src/linux/device-linux.cpp
@@ -92,7 +92,9 @@ int device_linux::update()
     /* Process only the next event, this can result in a delay if there are many
      * events queued up, but it'll prevent buttons from getting stuck, which happens
      * if the button released event is skipped */
-    read(m_fd, &m_event, sizeof(m_event));
+    if (read(m_fd, &m_event, sizeof(m_event)) != sizeof(m_event))
+        return update_result::NONE;
+
     uint16_t vc = 0;
     float vv = 0.0f;
     int result = update_result::NONE;


### PR DESCRIPTION
**OS: Linux (6.15.5-arch1-1)**

**Issue:**  When an axis demand is given, it repeatedly calls the axis handler, regardless of if the value has changed.

**Reason:** The return value of the read(...) call in update() is not being checked, resulting in m_event not changing. The old value of m_event is then used again to trigger the event handlers.

I noticed that there is a check for the button logic so that it doesn't repeat the button handler if the value is the same? I'm not sure if that's needed anymore but I left that in there in case it solved another problem that I'm not aware off.